### PR TITLE
Added new factory test typetags for version and sku

### DIFF
--- a/src/EmotiBitFactoryTest.cpp
+++ b/src/EmotiBitFactoryTest.cpp
@@ -37,6 +37,7 @@ const char* EmotiBitFactoryTest::TypeTag::TEST_FAIL = "FAIL\0";
 const char* EmotiBitFactoryTest::TypeTag::VERSION_VALIDATION = "VV\0";
 const char* EmotiBitFactoryTest::TypeTag::SKU_VALIDATION = "SV\0";
 
+#ifdef ARDUINO
 void EmotiBitFactoryTest::updateOutputString(String &output, const char* testType, const char* result)
 {
 	output += testType;
@@ -51,18 +52,18 @@ void EmotiBitFactoryTest::updateOutputString(String &output, const char* testTyp
 		output += MSG_TERM_CHAR;
 	}
 }
-#ifdef ARDUINO
-	void EmotiBitFactoryTest::sendMessage(String typeTag, String payload)
+
+void EmotiBitFactoryTest::sendMessage(String typeTag, String payload)
+{
+	Serial.print(EmotiBitFactoryTest::MSG_START_CHAR);
+	Serial.print(typeTag);
+	if (!payload.equals(""))
 	{
-		Serial.print(EmotiBitFactoryTest::MSG_START_CHAR);
-		Serial.print(typeTag);
-		if (!payload.equals(""))
-		{
-			Serial.print(EmotiBitFactoryTest::PAYLOAD_DELIMITER);
-			Serial.print(payload);
-		}
-		Serial.println(EmotiBitFactoryTest::MSG_TERM_CHAR);
+		Serial.print(EmotiBitFactoryTest::PAYLOAD_DELIMITER);
+		Serial.print(payload);
 	}
+	Serial.println(EmotiBitFactoryTest::MSG_TERM_CHAR);
+}
 
 	// returns the version from barcode string "SKU-VERSION-NUMBER"
 void EmotiBitFactoryTest::parseBarcode(Barcode* barcode)

--- a/src/EmotiBitFactoryTest.cpp
+++ b/src/EmotiBitFactoryTest.cpp
@@ -64,4 +64,34 @@ void EmotiBitFactoryTest::updateOutputString(char* output, const char* testType,
 		}
 		Serial.println(EmotiBitFactoryTest::MSG_TERM_CHAR);
 	}
+
+	// returns the version from barcode string "SKU-VERSION-NUMBER"
+int EmotiBitFactoryTest::getVersionFromBarcode(String barcode)
+{
+	String sku, emotibitVersion, emotibitNumber;
+	sku = barcode.substring(0, barcode.indexOf(BARCODE_DELIMITER));
+	barcode = barcode.substring(barcode.indexOf(BARCODE_DELIMITER) + 1);
+	emotibitVersion = barcode.substring(0, barcode.indexOf(BARCODE_DELIMITER));
+	emotibitNumber = barcode.substring(barcode.indexOf(BARCODE_DELIMITER) + 1);
+	// if barcode has V4
+	if (emotibitVersion.equals("V4"))
+	{
+		return (int)EmotiBitVersionController::EmotiBitVersion::V04A;
+	}
+	// if barcode has V3
+	else if (emotibitVersion.equals("V3"))
+	{
+		return (int)EmotiBitVersionController::EmotiBitVersion::V03B;
+	}
+	else
+	{
+		return -1;
+	}
+}
+
+// returns the sku from barcode string "SKU-VERSION-NUMBER"
+String EmotiBitFactoryTest::getSkuFromBarcode(String barcode)
+{
+	return barcode.substring(0, barcode.indexOf(BARCODE_DELIMITER));
+}
 #endif

--- a/src/EmotiBitFactoryTest.cpp
+++ b/src/EmotiBitFactoryTest.cpp
@@ -68,20 +68,20 @@ void EmotiBitFactoryTest::sendMessage(String typeTag, String payload)
 	// Parses the barcode 
 void EmotiBitFactoryTest::parseBarcode(Barcode* barcode)
 {
-	String tempEmotibitVersion;
 	barcode->sku = barcode->code.substring(0, barcode->code.indexOf(BARCODE_DELIMITER));
 	barcode->code = barcode->code.substring(barcode->code.indexOf(BARCODE_DELIMITER) + 1);
-	tempEmotibitVersion = barcode->code.substring(0, barcode->code.indexOf(BARCODE_DELIMITER));
+	barcode->emotibitVersion = barcode->code.substring(0, barcode->code.indexOf(BARCODE_DELIMITER));
 	barcode->emotibitNumber = barcode->code.substring(barcode->code.indexOf(BARCODE_DELIMITER) + 1);
-	// if barcode has V4
-	if (tempEmotibitVersion.equals("V4"))
-	{
-		barcode->emotibitVersion = (int)EmotiBitVersionController::EmotiBitVersion::V04A;
-	}
-	// if barcode has V3
-	else if (tempEmotibitVersion.equals("V3"))
-	{
-		barcode->emotibitVersion = (int)EmotiBitVersionController::EmotiBitVersion::V03B;
-	}
+}
+
+bool EmotiBitFactoryTest::validateVersionEstimate(String barcode, String estimate)
+{
+	// remove the leading "V" in version
+	barcode.remove(barcode.indexOf(EmotiBitVariants::VERSION_PREFIX),1);
+	estimate.remove(estimate.indexOf(EmotiBitVariants::VERSION_PREFIX),1);
+	if (barcode.toInt() == estimate.toInt())
+		return true;
+	else
+		return false;
 }
 #endif

--- a/src/EmotiBitFactoryTest.cpp
+++ b/src/EmotiBitFactoryTest.cpp
@@ -37,19 +37,18 @@ const char* EmotiBitFactoryTest::TypeTag::TEST_FAIL = "FAIL\0";
 const char* EmotiBitFactoryTest::TypeTag::VERSION_VALIDATION = "VV\0";
 const char* EmotiBitFactoryTest::TypeTag::SKU_VALIDATION = "SV\0";
 
-void EmotiBitFactoryTest::updateOutputString(char* output, const char* testType, const char* result)
+void EmotiBitFactoryTest::updateOutputString(String &output, const char* testType, const char* result)
 {
-	//char output[10]; // max posible for any test
-	strcat(output,testType);
-	strcat(output,TypeTag::TEST_RESULT_DELIMITER);
-	strcat(output,result);
+	output += testType;
+	output += TypeTag::TEST_RESULT_DELIMITER;
+	output += result;
 	if(result != TypeTag::NULL_VAL)
 	{
-		strcat(output,TypeTag::TEST_TYPE_DELIMITER);
+		output += TypeTag::TEST_TYPE_DELIMITER;
 	}
 	else
 	{
-		strcat(output, "***");
+		output += MSG_TERM_CHAR;
 	}
 }
 #ifdef ARDUINO

--- a/src/EmotiBitFactoryTest.cpp
+++ b/src/EmotiBitFactoryTest.cpp
@@ -66,32 +66,22 @@ void EmotiBitFactoryTest::updateOutputString(char* output, const char* testType,
 	}
 
 	// returns the version from barcode string "SKU-VERSION-NUMBER"
-int EmotiBitFactoryTest::getVersionFromBarcode(String barcode)
+void EmotiBitFactoryTest::parseBarcode(Barcode* barcode)
 {
-	String sku, emotibitVersion, emotibitNumber;
-	sku = barcode.substring(0, barcode.indexOf(BARCODE_DELIMITER));
-	barcode = barcode.substring(barcode.indexOf(BARCODE_DELIMITER) + 1);
-	emotibitVersion = barcode.substring(0, barcode.indexOf(BARCODE_DELIMITER));
-	emotibitNumber = barcode.substring(barcode.indexOf(BARCODE_DELIMITER) + 1);
+	String tempEmotibitVersion;
+	barcode->sku = barcode->code.substring(0, barcode->code.indexOf(BARCODE_DELIMITER));
+	barcode->code = barcode->code.substring(barcode->code.indexOf(BARCODE_DELIMITER) + 1);
+	tempEmotibitVersion = barcode->code.substring(0, barcode->code.indexOf(BARCODE_DELIMITER));
+	barcode->emotibitNumber = barcode->code.substring(barcode->code.indexOf(BARCODE_DELIMITER) + 1);
 	// if barcode has V4
-	if (emotibitVersion.equals("V4"))
+	if (tempEmotibitVersion.equals("V4"))
 	{
-		return (int)EmotiBitVersionController::EmotiBitVersion::V04A;
+		barcode->emotibitVersion = (int)EmotiBitVersionController::EmotiBitVersion::V04A;
 	}
 	// if barcode has V3
-	else if (emotibitVersion.equals("V3"))
+	else if (tempEmotibitVersion.equals("V3"))
 	{
-		return (int)EmotiBitVersionController::EmotiBitVersion::V03B;
+		barcode->emotibitVersion = (int)EmotiBitVersionController::EmotiBitVersion::V03B;
 	}
-	else
-	{
-		return -1;
-	}
-}
-
-// returns the sku from barcode string "SKU-VERSION-NUMBER"
-String EmotiBitFactoryTest::getSkuFromBarcode(String barcode)
-{
-	return barcode.substring(0, barcode.indexOf(BARCODE_DELIMITER));
 }
 #endif

--- a/src/EmotiBitFactoryTest.cpp
+++ b/src/EmotiBitFactoryTest.cpp
@@ -65,7 +65,7 @@ void EmotiBitFactoryTest::sendMessage(String typeTag, String payload)
 	Serial.println(EmotiBitFactoryTest::MSG_TERM_CHAR);
 }
 
-	// returns the version from barcode string "SKU-VERSION-NUMBER"
+	// Parses the barcode 
 void EmotiBitFactoryTest::parseBarcode(Barcode* barcode)
 {
 	String tempEmotibitVersion;

--- a/src/EmotiBitFactoryTest.cpp
+++ b/src/EmotiBitFactoryTest.cpp
@@ -4,7 +4,7 @@
 const char* EmotiBitFactoryTest::TypeTag::EMOTIBIT_VERSION = "EV\0";
 const char* EmotiBitFactoryTest::TypeTag::FIRMWARE_VERSION = "FV\0";
 const char* EmotiBitFactoryTest::TypeTag::EMOTIBIT_NUMBER = "EN\0";
-const char* EmotiBitFactoryTest::TypeTag::I2C_COMM_INIT = "TW";
+const char* EmotiBitFactoryTest::TypeTag::I2C_COMM_INIT = "TW\0";
 const char* EmotiBitFactoryTest::TypeTag::FLASH = "FL\0";
 const char* EmotiBitFactoryTest::TypeTag::SERIAL_NUMBER_WRITE = "SW\0";
 const char* EmotiBitFactoryTest::TypeTag::LED_CONTROLLER = "LC\0";
@@ -34,6 +34,8 @@ const char* EmotiBitFactoryTest::TypeTag::LED_YELLOW_OFF = "-Y\0";
 const char* EmotiBitFactoryTest::TypeTag::NULL_VAL = "\0";
 const char* EmotiBitFactoryTest::TypeTag::TEST_PASS = "PASS\0";
 const char* EmotiBitFactoryTest::TypeTag::TEST_FAIL = "FAIL\0";
+const char* EmotiBitFactoryTest::TypeTag::VERSION_VALIDATION = "VV\0";
+const char* EmotiBitFactoryTest::TypeTag::SKU_VALIDATION = "SV\0";
 
 void EmotiBitFactoryTest::updateOutputString(char* output, const char* testType, const char* result)
 {
@@ -41,7 +43,7 @@ void EmotiBitFactoryTest::updateOutputString(char* output, const char* testType,
 	strcat(output,testType);
 	strcat(output,TypeTag::TEST_RESULT_DELIMITER);
 	strcat(output,result);
-	if(result != TypeTag::TEST_FAIL && result != TypeTag::NULL_VAL)
+	if(result != TypeTag::NULL_VAL)
 	{
 		strcat(output,TypeTag::TEST_TYPE_DELIMITER);
 	}

--- a/src/EmotiBitFactoryTest.h
+++ b/src/EmotiBitFactoryTest.h
@@ -66,7 +66,7 @@ public:
 	static const char PAYLOAD_DELIMITER = ',';
 	static const char BARCODE_DELIMITER = '-';
 
-	static void updateOutputString(char * output, const char* testType, const char* result);
+	static void updateOutputString(String &output, const char* testType, const char* result);
 	#ifdef ARDUINO
 		static void sendMessage(String typeTag, String payload = "");
 		static void parseBarcode(Barcode* barcode);

--- a/src/EmotiBitFactoryTest.h
+++ b/src/EmotiBitFactoryTest.h
@@ -45,6 +45,8 @@ public:
 		static const char* LED_YELLOW_ON;
 		static const char* LED_YELLOW_OFF;
 		static const char* NULL_VAL;
+		static const char* VERSION_VALIDATION;
+		static const char* SKU_VALIDATION;
 	};
 
 	static const char MSG_START_CHAR = '@';

--- a/src/EmotiBitFactoryTest.h
+++ b/src/EmotiBitFactoryTest.h
@@ -5,6 +5,17 @@
 	// ToDo: Remove OF dependency for ofToString()
 	#include "ofMain.h"
 #endif // !ARDUINO
+
+#ifdef ARDUINO
+struct Barcode
+{
+	String code = "\0";
+	String sku = "\0";
+	int emotibitVersion = 0;
+	String emotibitNumber = "\0";
+};
+#endif
+
 class EmotiBitFactoryTest{
 public:
 	class TypeTag
@@ -58,7 +69,7 @@ public:
 	static void updateOutputString(char * output, const char* testType, const char* result);
 	#ifdef ARDUINO
 		static void sendMessage(String typeTag, String payload = "");
-		static int getVersionFromBarcode(String barcode);
-		static String getSkuFromBarcode(String barcode);
+		static void parseBarcode(Barcode* barcode);
 	#endif
 };
+

--- a/src/EmotiBitFactoryTest.h
+++ b/src/EmotiBitFactoryTest.h
@@ -5,13 +5,14 @@
 	// ToDo: Remove OF dependency for ofToString()
 	#include "ofMain.h"
 #endif // !ARDUINO
+#include "EmotiBitVariants.h"
 
 #ifdef ARDUINO
 struct Barcode
 {
 	String code = "\0";
 	String sku = "\0";
-	int emotibitVersion = 0;
+	String emotibitVersion = "\0";
 	String emotibitNumber = "\0";
 };
 #endif
@@ -70,6 +71,7 @@ public:
 		static void updateOutputString(String &output, const char* testType, const char* result);
 		static void sendMessage(String typeTag, String payload = "");
 		static void parseBarcode(Barcode* barcode);
+		static bool validateVersionEstimate(String barcode, String estimate);
 	#endif
 };
 

--- a/src/EmotiBitFactoryTest.h
+++ b/src/EmotiBitFactoryTest.h
@@ -65,8 +65,8 @@ public:
 	static const char MSG_TERM_CHAR = '~';
 	static const char PAYLOAD_DELIMITER = ',';
 	static const char BARCODE_DELIMITER = '-';
-	static const char ACK_FACTORY_MODE = '!';
-
+	static const char INIT_FACTORY_TEST = 'F';
+	static const char FIRMWARE_DELIMITER = '.';
 	#ifdef ARDUINO
 		static void updateOutputString(String &output, const char* testType, const char* result);
 		static void sendMessage(String typeTag, String payload = "");

--- a/src/EmotiBitFactoryTest.h
+++ b/src/EmotiBitFactoryTest.h
@@ -66,8 +66,8 @@ public:
 	static const char PAYLOAD_DELIMITER = ',';
 	static const char BARCODE_DELIMITER = '-';
 
-	static void updateOutputString(String &output, const char* testType, const char* result);
 	#ifdef ARDUINO
+		static void updateOutputString(String &output, const char* testType, const char* result);
 		static void sendMessage(String typeTag, String payload = "");
 		static void parseBarcode(Barcode* barcode);
 	#endif

--- a/src/EmotiBitFactoryTest.h
+++ b/src/EmotiBitFactoryTest.h
@@ -1,5 +1,6 @@
 #ifdef ARDUINO
 	#include <Arduino.h>
+	#include "EmotiBitVersionController.h"
 #else
 	// ToDo: Remove OF dependency for ofToString()
 	#include "ofMain.h"
@@ -52,9 +53,12 @@ public:
 	static const char MSG_START_CHAR = '@';
 	static const char MSG_TERM_CHAR = '~';
 	static const char PAYLOAD_DELIMITER = ',';
+	static const char BARCODE_DELIMITER = '-';
 
 	static void updateOutputString(char * output, const char* testType, const char* result);
 	#ifdef ARDUINO
 		static void sendMessage(String typeTag, String payload = "");
+		static int getVersionFromBarcode(String barcode);
+		static String getSkuFromBarcode(String barcode);
 	#endif
 };

--- a/src/EmotiBitFactoryTest.h
+++ b/src/EmotiBitFactoryTest.h
@@ -65,6 +65,7 @@ public:
 	static const char MSG_TERM_CHAR = '~';
 	static const char PAYLOAD_DELIMITER = ',';
 	static const char BARCODE_DELIMITER = '-';
+	static const char ACK_FACTORY_MODE = '!';
 
 	#ifdef ARDUINO
 		static void updateOutputString(String &output, const char* testType, const char* result);

--- a/src/EmotiBitFactoryTest.h
+++ b/src/EmotiBitFactoryTest.h
@@ -1,6 +1,5 @@
 #ifdef ARDUINO
 	#include <Arduino.h>
-	#include "EmotiBitVersionController.h"
 #else
 	// ToDo: Remove OF dependency for ofToString()
 	#include "ofMain.h"

--- a/src/EmotiBitVariants.cpp
+++ b/src/EmotiBitVariants.cpp
@@ -1,0 +1,3 @@
+#include "EmotiBitVariants.h"
+
+const char* EmotiBitVariants::EmotiBitSkuTags[] = { "EM\0", "MD\0" };

--- a/src/EmotiBitVariants.h
+++ b/src/EmotiBitVariants.h
@@ -1,0 +1,16 @@
+#pragma once
+
+class EmotiBitVariants
+{
+public:
+	enum class EmotiBitSkuType
+	{
+		INVALID = -1,
+		EM = 0,
+		MD = 1,
+		length 
+	};
+
+	static const char* EmotiBitSkuTags[2]; 
+	static const char VERSION_PREFIX = 'V';
+};


### PR DESCRIPTION
## Description
- Adds support for version and SKU validation using the barcode.
- Added new container to hold barcode data.
- Added new function to parse barcode.

## Compatiblity
- Required by the latest FW on https://github.com/EmotiBit/EmotiBit_FeatherWing/pull/153 to use these changes
- Required by the latest SW on https://github.com/connectedfuturelabs/EmotiBit_Factory_Test/pull/20

## Testing
- The format of barcode supported is
  - `SKU-VERSION-NUMBER`. Ex:  `MD-V4-123456`