### PR TITLE
Feat transmit emotibit serial number to oscilloscope

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit XPlat Utils
-version=1.4.0
+version=1.5.0
 author=Connected Future Labs
 maintainer=Connected Future Labs <info@connectedfuturelabs.com>
 sentence=A Utilities Library required for the successfull operation of EmotiBit FeatherWing and EmotiBit Oscilloscope Library

--- a/src/EmotiBitPacket.cpp
+++ b/src/EmotiBitPacket.cpp
@@ -364,7 +364,7 @@ int16_t EmotiBitPacket::getPacketElement(const String& packet, String& element, 
 	return nextStartChar;
 }
 
-int16_t EmotiBitPacket::getPacketKeyedValue(const String &packet, const String &key, String &value, uint16_t startChar)
+int16_t EmotiBitPacket::getPacketKeyedValue(const String &packet, const String &key, String &value, int16_t startChar)
 {
 	String element;
 	do

--- a/src/EmotiBitPacket.cpp
+++ b/src/EmotiBitPacket.cpp
@@ -78,6 +78,7 @@ const char* EmotiBitPacket::TypeTag::EMOTIBIT_CONNECT = "EC\0";
 
 const char* EmotiBitPacket::PayloadLabel::CONTROL_PORT = "CP\0";
 const char* EmotiBitPacket::PayloadLabel::DATA_PORT = "DP\0";
+const char* EmotiBitPacket::PayloadLabel::DEVICE_ID = "DI\0";
 const char* EmotiBitPacket::PayloadLabel::RECORDING_STATUS = "RS\0";
 const char* EmotiBitPacket::PayloadLabel::POWER_STATUS = "PS\0";
 const char* EmotiBitPacket::PayloadLabel::LSL_MARKER_RX_TIMESTAMP = "LR\0";

--- a/src/EmotiBitPacket.h
+++ b/src/EmotiBitPacket.h
@@ -233,6 +233,7 @@ public:
 	public:
 		static const char* CONTROL_PORT;
 		static const char* DATA_PORT;
+		static const char* DEVICE_ID;
 		static const char* RECORDING_STATUS;
 		static const char* POWER_STATUS;
 		static const char* LSL_MARKER_RX_TIMESTAMP;

--- a/src/EmotiBitPacket.h
+++ b/src/EmotiBitPacket.h
@@ -267,7 +267,7 @@ public:
 	/// @param key to search for in the packet
 	/// @param value is filled with the extracted element
 	/// @return startChar of the value element or -1 if no key/value exists
-	static int16_t getPacketKeyedValue(const String &packet, const String &key, String &value, uint16_t startChar = 0);
+	static int16_t getPacketKeyedValue(const String &packet, const String &key, String &value, int16_t startChar = 0);
 
 #ifndef ARDUINO
 	static bool getHeader(const vector<string>& packet, Header &packetHeader); // Returns false if the packet is malformed


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
- Adds support to send EmotiBit serial number in the `HELLO_HOST` emotibit packet.
  - Used by new oscilloscope to identify emotibits by serial number
-  Bug fix:
  - Solved an issue with implicit cast from `int` to `uint` was starting an infinite while loop

# Requirements
- None

# Required by
- https://github.com/EmotiBit/EmotiBit_FeatherWing/pull/264
- https://github.com/EmotiBit/ofxEmotiBit/pull/188

# Issues Referenced
<!-- If Any -->
- None

# Documentation update
None

# Testing
- None

# Checklist to allow merge
- [ ] All dependent repositories used were on branch `master`
- Software
  - [ ] Passed testing on Windows
  - [ ] Passed testing on macOS
  - [ ] Passed testing on linux (ubuntu)
- Firmware
  - [ ] Set testingMode to TestingMode::NONE
  - [ ] Set const bool `DIGITAL_WRITE_DEBUG` = false (if set true while testing)
  - [ ] Update version in EmotiBit.h
  - [ ] Update library.properties to the correct version (should match EmotiBit.h)
- [ ] Update software bundle version in `ofxEmotiBitVersion.h`
- [ ] doxygen style comments included for new code snippets
- [ ] Required documentation udpated

## Screenshots:
