### PR TITLE
Introducing typetags to support WiFi creds over serial

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit XPlat Utils
-version=1.5.0
+version=1.6.0
 author=Connected Future Labs
 maintainer=Connected Future Labs <info@connectedfuturelabs.com>
 sentence=A Utilities Library required for the successfull operation of EmotiBit FeatherWing and EmotiBit Oscilloscope Library

--- a/src/EmotiBitFactoryTest.cpp
+++ b/src/EmotiBitFactoryTest.cpp
@@ -57,20 +57,13 @@ void EmotiBitFactoryTest::updateOutputString(String &output, const char* testTyp
 	}
 	else
 	{
-		output += MSG_TERM_CHAR;
+		output += EmotiBitSerial::MSG_TERM_CHAR;
 	}
 }
 
 void EmotiBitFactoryTest::sendMessage(String typeTag, String payload)
 {
-	Serial.print(EmotiBitFactoryTest::MSG_START_CHAR);
-	Serial.print(typeTag);
-	if (!payload.equals(""))
-	{
-		Serial.print(EmotiBitFactoryTest::PAYLOAD_DELIMITER);
-		Serial.print(payload);
-	}
-	Serial.println(EmotiBitFactoryTest::MSG_TERM_CHAR);
+	EmotiBitSerial::sendMessage(typeTag, payload);
 }
 
 	// Parses the barcode 
@@ -120,13 +113,13 @@ void EmotiBitFactoryTest::convertBarcodeToVariantInfo(Barcode barcode, EmotiBitV
 string EmotiBitFactoryTest::createPacket(string typeTag, string payload)
 {
 	string s = "";
-	s += EmotiBitFactoryTest::MSG_START_CHAR;
+	s += EmotiBitSerial::MSG_START_CHAR;
 	s += typeTag;
 	if (payload.length() > 0) {
-		s += EmotiBitFactoryTest::PAYLOAD_DELIMITER;
+		s += EmotiBitSerial::PAYLOAD_DELIMITER;
 		s += payload;
 	}
-	s += EmotiBitFactoryTest::MSG_TERM_CHAR;
+	s += EmotiBitSerial::MSG_TERM_CHAR;
 	return s;
 }
 #endif

--- a/src/EmotiBitFactoryTest.h
+++ b/src/EmotiBitFactoryTest.h
@@ -7,7 +7,7 @@
 	#include "ofMain.h"
 #endif // !ARDUINO
 #include "EmotiBitVariants.h"
-
+#include "EmotiBitSerial.h"
 
 #ifdef ARDUINO
 struct Barcode
@@ -70,11 +70,9 @@ public:
 		static const char* EMOTIBIT_STORAGE;
 	};
 
-	static const char MSG_START_CHAR = '@';
-	static const char MSG_TERM_CHAR = '~';
-	static const char PAYLOAD_DELIMITER = ',';
+	// definitions that can exist outside the scope of factory test are defined in EmotiBitSerial. 
 	static const char BARCODE_DELIMITER = '-';
-	static const char INIT_FACTORY_TEST = 'F';
+	static const char INIT_FACTORY_TEST = EmotiBitSerial::Inputs::FACTORY_TEST_MODE;//'F';
 	static const char FIRMWARE_DELIMITER = '.';
 	#ifdef ARDUINO
 	static void updateOutputString(String &output, const char* testType, const char* result);

--- a/src/EmotiBitPacket.cpp
+++ b/src/EmotiBitPacket.cpp
@@ -36,7 +36,7 @@ const char* EmotiBitPacket::TypeTag::BUTTON_PRESS_LONG = "BL\0";
 const char* EmotiBitPacket::TypeTag::DATA_CLIPPING = "DC\0";
 const char* EmotiBitPacket::TypeTag::DATA_OVERFLOW = "DO\0";
 const char* EmotiBitPacket::TypeTag::SD_CARD_PERCENT = "SD\0";
-const char* EmotiBitPacket::TypeTag::RESET = "RS\0"; // still necessary?
+const char* EmotiBitPacket::TypeTag::RESET = "RS\0";
 const char* EmotiBitPacket::TypeTag::EMOTIBIT_DEBUG = "DB\0";
 const char* EmotiBitPacket::TypeTag::ACK = "AK\0";
 const char* EmotiBitPacket::TypeTag::NACK = "NK\0";
@@ -79,7 +79,6 @@ const char* EmotiBitPacket::TypeTag::EMOTIBIT_CONNECT = "EC\0";
 // Sd Card TypeTags
 const char* EmotiBitPacket::TypeTag::WIFI_ADD = "WA\0";
 const char* EmotiBitPacket::TypeTag::WIFI_DELETE = "WD\0";
-const char* EmotiBitPacket::TypeTag::EMOTIBIT_RESET = "ER\0";
 
 const char* EmotiBitPacket::PayloadLabel::CONTROL_PORT = "CP\0";
 const char* EmotiBitPacket::PayloadLabel::DATA_PORT = "DP\0";

--- a/src/EmotiBitPacket.cpp
+++ b/src/EmotiBitPacket.cpp
@@ -39,6 +39,7 @@ const char* EmotiBitPacket::TypeTag::SD_CARD_PERCENT = "SD\0";
 const char* EmotiBitPacket::TypeTag::RESET = "RS\0"; // still necessary?
 const char* EmotiBitPacket::TypeTag::EMOTIBIT_DEBUG = "DB\0";
 const char* EmotiBitPacket::TypeTag::ACK = "AK\0";
+const char* EmotiBitPacket::TypeTag::NACK = "NK\0";
 const char* EmotiBitPacket::TypeTag::REQUEST_DATA = "RD\0";
 const char* EmotiBitPacket::TypeTag::TIMESTAMP_EMOTIBIT = "TE\0";
 const char* EmotiBitPacket::TypeTag::TIMESTAMP_LOCAL = "TL\0";

--- a/src/EmotiBitPacket.cpp
+++ b/src/EmotiBitPacket.cpp
@@ -75,6 +75,10 @@ const char* EmotiBitPacket::TypeTag::PONG = "PO\0";
 const char* EmotiBitPacket::TypeTag::HELLO_EMOTIBIT = "HE\0";
 const char* EmotiBitPacket::TypeTag::HELLO_HOST = "HH\0";
 const char* EmotiBitPacket::TypeTag::EMOTIBIT_CONNECT = "EC\0";
+// Sd Card TypeTags
+const char* EmotiBitPacket::TypeTag::WIFI_ADD = "WA\0";
+const char* EmotiBitPacket::TypeTag::WIFI_DELETE = "WD\0";
+const char* EmotiBitPacket::TypeTag::EMOTIBIT_RESET = "ER\0";
 
 const char* EmotiBitPacket::PayloadLabel::CONTROL_PORT = "CP\0";
 const char* EmotiBitPacket::PayloadLabel::DATA_PORT = "DP\0";

--- a/src/EmotiBitPacket.cpp
+++ b/src/EmotiBitPacket.cpp
@@ -76,9 +76,12 @@ const char* EmotiBitPacket::TypeTag::PONG = "PO\0";
 const char* EmotiBitPacket::TypeTag::HELLO_EMOTIBIT = "HE\0";
 const char* EmotiBitPacket::TypeTag::HELLO_HOST = "HH\0";
 const char* EmotiBitPacket::TypeTag::EMOTIBIT_CONNECT = "EC\0";
-// Sd Card TypeTags
+// WiFi Credential management TypeTags
 const char* EmotiBitPacket::TypeTag::WIFI_ADD = "WA\0";
 const char* EmotiBitPacket::TypeTag::WIFI_DELETE = "WD\0";
+
+//Information Exchange TypeTags
+const char* EmotiBitPacket::TypeTag::LIST = "LS\0";
 
 const char* EmotiBitPacket::PayloadLabel::CONTROL_PORT = "CP\0";
 const char* EmotiBitPacket::PayloadLabel::DATA_PORT = "DP\0";

--- a/src/EmotiBitPacket.h
+++ b/src/EmotiBitPacket.h
@@ -203,6 +203,9 @@ public:
 		static const char* EMOTIBIT_DISCONNECT;
 		static const char* SERIAL_DATA_ON;
 		static const char* SERIAL_DATA_OFF;
+		static const char* WIFI_ADD;
+		static const char* WIFI_DELETE;
+		static const char* EMOTIBIT_RESET;
 		//static const char* KEEP_ALIVE;
 		static const char* ACK;
 		static const char* REQUEST_DATA;

--- a/src/EmotiBitPacket.h
+++ b/src/EmotiBitPacket.h
@@ -206,7 +206,6 @@ public:
 		static const char* SERIAL_DATA_OFF;
 		static const char* WIFI_ADD;
 		static const char* WIFI_DELETE;
-		static const char* EMOTIBIT_RESET;
 		//static const char* KEEP_ALIVE;
 		static const char* ACK;
 		static const char* NACK;

--- a/src/EmotiBitPacket.h
+++ b/src/EmotiBitPacket.h
@@ -138,6 +138,7 @@ public:
 		HELLO_EMOTIBIT,	// Hello Emotibit (used to establish communications)
 		// General Comms
 		ACK,
+		NACK,
 		REQUEST_DATA,	// Request data, data = list of requested data types
 		PING,	// Ping
 		PONG,	// Pong
@@ -208,6 +209,7 @@ public:
 		static const char* EMOTIBIT_RESET;
 		//static const char* KEEP_ALIVE;
 		static const char* ACK;
+		static const char* NACK;
 		static const char* REQUEST_DATA;
 		static const char* PING;
 		static const char* PONG;

--- a/src/EmotiBitPacket.h
+++ b/src/EmotiBitPacket.h
@@ -206,6 +206,7 @@ public:
 		static const char* SERIAL_DATA_OFF;
 		static const char* WIFI_ADD;
 		static const char* WIFI_DELETE;
+		static const char* LIST;
 		//static const char* KEEP_ALIVE;
 		static const char* ACK;
 		static const char* NACK;

--- a/src/EmotiBitSerial.cpp
+++ b/src/EmotiBitSerial.cpp
@@ -25,7 +25,7 @@ bool EmotiBitSerial::parseSerialMessage(String message, String &typetag, String 
 					// msg of the type @TT,~
 					return false;
 				}
-				else if (payloadDelimiterIndex == messageDelimiterIndex - 2)
+				else if (payloadDelimiterIndex == messageDelimiterIndex - 2 && isSpace(message.charAt(payloadDelimiterIndex+1)))
 				{
 					// msg of the type @TT, ~
 					return false;

--- a/src/EmotiBitSerial.cpp
+++ b/src/EmotiBitSerial.cpp
@@ -5,15 +5,39 @@ bool EmotiBitSerial::parseSerialMessage(String message, String &typetag, String 
 {
 	if(message.charAt(0) == MSG_START_CHAR)
 	{
-		int payloadDelimiterIndex = message.indexOf(PAYLOAD_DELIMITER);
+		// msg has valid start condition
 		int messageDelimiterIndex = message.indexOf(MSG_TERM_CHAR);
-		if (payloadDelimiterIndex > 0 && messageDelimiterIndex > 0)
+		if(messageDelimiterIndex > 0)
 		{
-			typetag = message.substring(1, payloadDelimiterIndex);
-			payload = message.substring(payloadDelimiterIndex + 1, messageDelimiterIndex);
-			// ToDo: Add a debug pre-processor guard instead of comments
-			//Serial.print("typetag: ");Serial.println(typetag);
-			//Serial.print("payload: ");Serial.println(payload);
+			// valid msg
+			int payloadDelimiterIndex = message.indexOf(PAYLOAD_DELIMITER);
+			if (payloadDelimiterIndex < 0 )
+			{
+				// No payload
+				// msg of the type @TT~
+				typetag = message.substring(1, messageDelimiterIndex);
+				payload = "";
+			}
+			else
+			{
+				if (payloadDelimiterIndex == messageDelimiterIndex - 1)
+				{
+					// msg of the type @TT,~
+					return false;
+				}
+				else if (payloadDelimiterIndex == messageDelimiterIndex - 2)
+				{
+					// msg of the type @TT, ~
+					return false;
+				}
+				else
+				{
+					// msg of the type @TT,payload~
+					typetag = message.substring(1, payloadDelimiterIndex);
+					payload = message.substring(payloadDelimiterIndex + 1, messageDelimiterIndex);
+
+				}
+			}
 		}
 		else
 		{
@@ -24,12 +48,21 @@ bool EmotiBitSerial::parseSerialMessage(String message, String &typetag, String 
 	{
 		return false;
 	}
+	// ToDo: Add a debug pre-processor guard instead of comments
+	//Serial.print("typetag: ");Serial.println(typetag);
+	//Serial.print("payload: ");Serial.println(payload);
 	return true;
 }
 
 void EmotiBitSerial::sendMessage(String typeTag, String payload)
 {
-    String msg = MSG_START_CHAR + typeTag + PAYLOAD_DELIMITER + payload + MSG_TERM_CHAR;
-    Serial.println(msg);
+    Serial.print(EmotiBitSerial::MSG_START_CHAR);
+	Serial.print(typeTag);
+	if (!payload.equals(""))
+	{
+		Serial.print(EmotiBitSerial::PAYLOAD_DELIMITER);
+		Serial.print(payload);
+	}
+	Serial.println(EmotiBitSerial::MSG_TERM_CHAR);
 }
 #endif

--- a/src/EmotiBitSerial.cpp
+++ b/src/EmotiBitSerial.cpp
@@ -1,0 +1,34 @@
+#include "EmotiBitSerial.h"
+
+#ifdef ARDUINO
+bool EmotiBitSerial::parseSerialMessage(String message, String &typetag, String &payload)
+{
+	if(message.charAt(0) == MSG_START_CHAR)
+	{
+		int payloadDelimiterIndex = message.indexOf(PAYLOAD_DELIMITER);
+		int messageDelimiterIndex = message.indexOf(MSG_TERM_CHAR);
+		if (payloadDelimiterIndex > 0 && messageDelimiterIndex > 0)
+		{
+			typetag = message.substring(1, payloadDelimiterIndex);
+			payload = message.substring(payloadDelimiterIndex + 1, messageDelimiterIndex);
+			Serial.print("typetag: ");Serial.println(typetag);
+			Serial.print("payload: ");Serial.println(payload);
+		}
+		else
+		{
+			return false;
+		}
+	}
+	else
+	{
+		return false;
+	}
+	return true;
+}
+
+void EmotiBitSerial::sendMessage(String typeTag, String payload)
+{
+    String msg = MSG_START_CHAR + typeTag + PAYLOAD_DELIMITER + payload + MSG_TERM_CHAR;
+    Serial.println(msg);
+}
+#endif

--- a/src/EmotiBitSerial.cpp
+++ b/src/EmotiBitSerial.cpp
@@ -11,8 +11,9 @@ bool EmotiBitSerial::parseSerialMessage(String message, String &typetag, String 
 		{
 			typetag = message.substring(1, payloadDelimiterIndex);
 			payload = message.substring(payloadDelimiterIndex + 1, messageDelimiterIndex);
-			Serial.print("typetag: ");Serial.println(typetag);
-			Serial.print("payload: ");Serial.println(payload);
+			// ToDo: Add a debug pre-processor guard instead of comments
+			//Serial.print("typetag: ");Serial.println(typetag);
+			//Serial.print("payload: ");Serial.println(payload);
 		}
 		else
 		{

--- a/src/EmotiBitSerial.h
+++ b/src/EmotiBitSerial.h
@@ -14,4 +14,11 @@ public:
     static const char MSG_START_CHAR = '@';
 	static const char MSG_TERM_CHAR = '~';
 	static const char PAYLOAD_DELIMITER = ',';
+    struct Inputs
+    {
+        static const char RESET = 'R';
+        static const char CONFIG_UPDATE = 'C';
+        static const char DEBUG_MODE = 'D';
+        static const char FACTORY_TEST_MODE = 'F';
+    };
 };

--- a/src/EmotiBitSerial.h
+++ b/src/EmotiBitSerial.h
@@ -1,0 +1,17 @@
+#pragma once
+#ifdef ARDUINO
+#include <Arduino.h>
+#endif
+
+class EmotiBitSerial
+{
+public:
+#ifdef ARDUINO
+    static bool parseSerialMessage(String message, String &typetag, String &payload);
+    static void sendMessage(String typeTag, String payload = "");
+    
+#endif
+    static const char MSG_START_CHAR = '@';
+	static const char MSG_TERM_CHAR = '~';
+	static const char PAYLOAD_DELIMITER = ',';
+};

--- a/src/EmotiBitSerial.h
+++ b/src/EmotiBitSerial.h
@@ -14,11 +14,15 @@ public:
     static const char MSG_START_CHAR = '@';
 	static const char MSG_TERM_CHAR = '~';
 	static const char PAYLOAD_DELIMITER = ',';
+
+    /*!
+    * Inputs that can change EmotiBit functionality. These prompts can be made by a user or by a software.
+    */
     struct Inputs
     {
-        static const char RESET = 'R';
-        static const char CONFIG_UPDATE = 'C';
-        static const char DEBUG_MODE = 'D';
-        static const char FACTORY_TEST_MODE = 'F';
+        static const char RESET = 'R';  ///< resets MCU
+        static const char CONFIG_UPDATE = 'C';  ///< Enters config file update mode.
+        static const char DEBUG_MODE = 'D';   ///< Enters Debug mode
+        static const char FACTORY_TEST_MODE = 'F';  ///< Enters Factory Test mode
     };
 };

--- a/src/EmotiBitSerial.h
+++ b/src/EmotiBitSerial.h
@@ -20,6 +20,7 @@ public:
     */
     struct Inputs
     {
+        static const char ADC_CORRECTION_MODE = 'A';  ///< enter ADC correction mode. Backward compatibility to emotibit v2/v3 
         static const char RESET = 'R';  ///< resets MCU
         static const char CONFIG_UPDATE = 'C';  ///< Enters config file update mode.
         static const char DEBUG_MODE = 'D';   ///< Enters Debug mode

--- a/src/EmotiBitSerial.h
+++ b/src/EmotiBitSerial.h
@@ -22,7 +22,7 @@ public:
     {
         static const char ADC_CORRECTION_MODE = 'A';  ///< enter ADC correction mode. Backward compatibility to emotibit v2/v3 
         static const char RESET = 'R';  ///< resets MCU
-        static const char CONFIG_UPDATE = 'C';  ///< Enters config file update mode.
+        static const char CRED_UPDATE = 'C';  ///< Enters config file update mode.
         static const char DEBUG_MODE = 'D';   ///< Enters Debug mode
         static const char FACTORY_TEST_MODE = 'F';  ///< Enters Factory Test mode
     };


### PR DESCRIPTION
# Description
- Adds typetags to enable updating WiFi creds over serial
- Adds `EmotiBitSerial` class
  - Supporting functions to send and parse messages over serial

# Requirements
- None


# Issues Referenced
<!-- If Any -->
- None

# Documentation update
None

# Notes for Reviewer
- None

# Testing
- Check https://github.com/EmotiBit/EmotiBit_FeatherWing/pull/283



# Checklist to allow merge
- [ ] All dependent repositories used were on branch `master`
- Firmware
  - [ ] Set testingMode to TestingMode::NONE
  - [ ] Set [const bool `DIGITAL_WRITE_DEBUG`](https://github.com/EmotiBit/EmotiBit_FeatherWing/blob/e2ed2dcb70c57c33f70e3a131f82c16627b519df/EmotiBit.h#L58) = false (if set true while testing)
  - [ ] Update version in EmotiBit.h
  - [ ] Update library.properties to the correct version (should match EmotiBit.h)
- [ ] doxygen style comments included for new code snippets
- [ ] Required documentation updated


## Screenshots:
